### PR TITLE
add GetEntityOrigin

### DIFF
--- a/packages/s2ts/types/cspointscript.d.ts
+++ b/packages/s2ts/types/cspointscript.d.ts
@@ -62,6 +62,13 @@ interface Instance {
      */
     GetPlayerPawn(playerId: string | number | boolean): Pawn | undefined
 
+     /**
+     * Gets the origin of a entity.
+     *
+     * @returns an array of the x y z values.
+     */
+    GetEntityOrigin(entity: Entity | Pawn): [number, number, number]
+
     /**
      * Triggers an action on an entity.
      *


### PR DESCRIPTION
ive been using this one a lot and saw its missing in this compiler

example usage:

```ts
var playerPos = Instance.GetEntityOrigin(Instance.GetPlayerPawn(0));
```