### PR TITLE
Added '{projectPath}/scripts/vscripts' to rollup modulePath

### DIFF
--- a/packages/s2ts/src/compiler/rollup.ts
+++ b/packages/s2ts/src/compiler/rollup.ts
@@ -44,7 +44,10 @@ export const bundleImports = async (pathForProject: string, file: VtsFile): Prom
         input: file.name,
         plugins: [
             resolve({
-                modulePaths: [path.join(pathForProject, "node_modules")],
+                modulePaths: [
+		    path.join(pathForProject, "node_modules"),
+		    path.join(pathForProject, "scripts", "vscripts"),
+		],
                 extensions: supportedExtensions
             }),
             commonjs(),


### PR DESCRIPTION
Including the scripts/vscripts folder in the rollup modulePath resolved my issues with local imports.